### PR TITLE
fix: Use last_success_time for last_synced

### DIFF
--- a/custom_components/nexxtmove/entity.py
+++ b/custom_components/nexxtmove/entity.py
@@ -79,7 +79,7 @@ class NexxtmoveEntity(CoordinatorEntity[NexxtmoveDataUpdateCoordinator]):
             return {}
 
         attributes = {
-            "last_synced": getattr(self.coordinator, "last_success", None),
+            "last_synced": getattr(self.coordinator, "last_success_time", None),
         }
 
         if item.extra_attributes:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the last synced time display to reference the correct timing information source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->